### PR TITLE
feat : 달력 스케줄 길이대로 달력에 넣기

### DIFF
--- a/app/myschedule/page.tsx
+++ b/app/myschedule/page.tsx
@@ -122,7 +122,7 @@ const MySchedule = () => {
 						<CustomCalendar updatedList={updatedList} />
 					</div>
 					<div className="w-1/2 mt-20 ml-10 flex flex-col justify-center">
-						<div className="enrollContainer w-1/2 flex flex-col justify-center mx-auto mt-4 border-solid border-4 border-black rounded-md">
+						<div className="enrollContainer w-1/2 flex flex-col justify-center mx-auto mt-4 border-solid border-2 shadow rounded-md">
 							<p className="schedule__title mt-4 text-center font-primary-font">
 								내 일정을 입력해보세요
 							</p>

--- a/app/myschedule/page.tsx
+++ b/app/myschedule/page.tsx
@@ -78,13 +78,10 @@ const MySchedule = () => {
 		const currentMonth = parseInt(destination.droppableId.split('-')[2], 10);
 		const currentDay = parseInt(destination.droppableId.split('-')[3], 10);
 		const draggedItem = tripList.find((item) => item.trip_id === draggableId);
-		console.log(draggedItem);
 
 		// 만약 드래그 했으면 달력에 특정 날짜에 넣기 위해 특정 날짜를 지칭하는 day 속성 추가
 		if (draggedItem) {
-			console.log(currentDay);
 			const draggedLength = draggedItem.trip_schedule;
-			// const startDay = currentDay;
 			const endDay = currentDay + draggedLength - 1;
 			const updatedItem = {
 				...draggedItem,
@@ -93,19 +90,19 @@ const MySchedule = () => {
 				currentDay,
 				endDay,
 			};
-			const newUpdatedList = [...updatedList, updatedItem]; // customCalendar에 전해줄 새로운 배열 만듦 -> firebase에 더함 예정
-
-			// 드래그 한 것 제외한 나머지 배열 tripList로 업데이트 해줌
+			const newUpdatedList = [...updatedList, updatedItem];
 			const newTripList = tripList.filter(
 				(item) => item.trip_id !== draggableId,
 			);
 			if (destination.droppableId === 'myScheduleList') {
-				const reorderedTripList = reorder(
-					tripList,
-					source.index,
-					destination.index,
-				);
-				setTripList(reorderedTripList);
+				if (source.droppableId === 'myScheduleList') {
+					const reorderedTripList = reorder(
+						tripList,
+						source.index,
+						destination.index,
+					);
+					setTripList(reorderedTripList);
+				}
 			} else {
 				setUpdatedList(newUpdatedList);
 				setTripList(newTripList);
@@ -117,9 +114,6 @@ const MySchedule = () => {
 	const removeItem = () => {
 		setTripList([]);
 	};
-	// useEffect(()=>{
-
-	// },[tripList])
 	return (
 		<DragDropContext onDragEnd={onDragEnd}>
 			<div className="container mx-auto">

--- a/app/myschedule/page.tsx
+++ b/app/myschedule/page.tsx
@@ -7,11 +7,6 @@ import { useQuery } from '@tanstack/react-query';
 
 import _ from 'lodash';
 
-// calendar 관련 components
-// import MyCalendar from '@/components/Calendar/Calendar';
-
-/* 드래그 기능 추가 시 필요한 import 구문 */
-// import { DragDropContext } from 'react-beautiful-dnd';
 import { DragDropContext, DropResult, Droppable } from '@hello-pangea/dnd';
 import { useSession } from 'next-auth/react';
 import CustomCalendar from '@/components/Calendar/CustomCalendar';
@@ -47,7 +42,7 @@ const MySchedule = () => {
 	useEffect(() => {
 		if (data && data.trip_list) {
 			setTripList(data.trip_list);
-			setUpdatedList(data.trip_list);
+			// setUpdatedList(data.trip_list);
 		}
 	}, [data]);
 
@@ -79,20 +74,14 @@ const MySchedule = () => {
 			return;
 		}
 		// find로 draggableId와 같은 trip_id 찾음 (draggableId = trip.trip_id)
+		const currentYear = parseInt(destination.droppableId.split('-')[1], 10);
+		const currentMonth = parseInt(destination.droppableId.split('-')[2], 10);
+		const currentDay = parseInt(destination.droppableId.split('-')[3], 10);
 		const draggedItem = tripList.find((item) => item.trip_id === draggableId);
+		console.log(draggedItem);
 
 		// 만약 드래그 했으면 달력에 특정 날짜에 넣기 위해 특정 날짜를 지칭하는 day 속성 추가
 		if (draggedItem) {
-			// const dayNumber = parseInt(
-			// 	destination.droppableId.replace('droppable-', ''),
-			// 	10,
-			// );
-			// console.log(dayNumber);
-			const currentYear = parseInt(destination.droppableId.split('-')[1], 10);
-			const currentMonth = parseInt(destination.droppableId.split('-')[2], 10);
-			const currentDay = parseInt(destination.droppableId.split('-')[3], 10);
-			console.log(currentYear);
-			console.log(currentMonth);
 			console.log(currentDay);
 			const draggedLength = draggedItem.trip_schedule;
 			// const startDay = currentDay;
@@ -104,7 +93,6 @@ const MySchedule = () => {
 				currentDay,
 				endDay,
 			};
-			// console.log(updatedItem); // day 속성 추가해서 dayNumber 넣어줌
 			const newUpdatedList = [...updatedList, updatedItem]; // customCalendar에 전해줄 새로운 배열 만듦 -> firebase에 더함 예정
 
 			// 드래그 한 것 제외한 나머지 배열 tripList로 업데이트 해줌
@@ -134,9 +122,6 @@ const MySchedule = () => {
 	// },[tripList])
 	return (
 		<DragDropContext onDragEnd={onDragEnd}>
-			{/* <Droppable droppableId="mySchedule">
-				{(provided) => (
-					<div ref={provided.innerRef} {...provided.droppableProps}> */}
 			<div className="container mx-auto">
 				<div className="flex flex-row justify-between">
 					<div className="w-1/2 mt-20">
@@ -150,7 +135,7 @@ const MySchedule = () => {
 							<Droppable droppableId="myScheduleList">
 								{(provided) => (
 									<div ref={provided.innerRef} {...provided.droppableProps}>
-										<div className="scheduleList w-full my-4 text-center flex flex-col justify-center">
+										<div className="scheduleList w-1/2 mx-auto my-4 text-center flex flex-col justify-center">
 											{tripList.map((trip: Trip, index: number) => (
 												<MyScheduleItem
 													key={trip.trip_id}
@@ -182,9 +167,6 @@ const MySchedule = () => {
 					</div>
 				</div>
 			</div>
-			{/* </div>
-				)}
-			</Droppable> */}
 		</DragDropContext>
 	);
 };

--- a/app/myschedule/page.tsx
+++ b/app/myschedule/page.tsx
@@ -58,6 +58,13 @@ const MySchedule = () => {
 	if (error) {
 		return <div>error</div>;
 	}
+
+	const reorder = (list: Trip[], startIndex: number, endIndex: number) => {
+		const result = Array.from(list);
+		const [removed] = result.splice(startIndex, 1);
+		result.splice(endIndex, 0, removed);
+		return result;
+	};
 	const onDragEnd = (result: DropResult) => {
 		const { destination, source, draggableId } = result;
 		// 만약 드롭 하지 않았으면 넘어감
@@ -76,21 +83,48 @@ const MySchedule = () => {
 
 		// 만약 드래그 했으면 달력에 특정 날짜에 넣기 위해 특정 날짜를 지칭하는 day 속성 추가
 		if (draggedItem) {
-			const dayNumber = parseInt(
-				destination.droppableId.replace('droppable-', ''),
-				10,
-			);
-			const updatedItem = { ...draggedItem, day: dayNumber }; // day 속성 추가해서 dayNumber 넣어줌
+			// const dayNumber = parseInt(
+			// 	destination.droppableId.replace('droppable-', ''),
+			// 	10,
+			// );
+			// console.log(dayNumber);
+			const currentYear = parseInt(destination.droppableId.split('-')[1], 10);
+			const currentMonth = parseInt(destination.droppableId.split('-')[2], 10);
+			const currentDay = parseInt(destination.droppableId.split('-')[3], 10);
+			console.log(currentYear);
+			console.log(currentMonth);
+			console.log(currentDay);
+			const draggedLength = draggedItem.trip_schedule;
+			// const startDay = currentDay;
+			const endDay = currentDay + draggedLength - 1;
+			const updatedItem = {
+				...draggedItem,
+				currentYear,
+				currentMonth,
+				currentDay,
+				endDay,
+			};
+			// console.log(updatedItem); // day 속성 추가해서 dayNumber 넣어줌
 			const newUpdatedList = [...updatedList, updatedItem]; // customCalendar에 전해줄 새로운 배열 만듦 -> firebase에 더함 예정
 
 			// 드래그 한 것 제외한 나머지 배열 tripList로 업데이트 해줌
 			const newTripList = tripList.filter(
 				(item) => item.trip_id !== draggableId,
 			);
-			setUpdatedList(newUpdatedList);
-			setTripList(newTripList);
+			if (destination.droppableId === 'myScheduleList') {
+				const reorderedTripList = reorder(
+					tripList,
+					source.index,
+					destination.index,
+				);
+				setTripList(reorderedTripList);
+			} else {
+				setUpdatedList(newUpdatedList);
+				setTripList(newTripList);
+			}
 		}
 	};
+
 	// 일단 다 삭제 하도록..
 	const removeItem = () => {
 		setTripList([]);
@@ -100,20 +134,22 @@ const MySchedule = () => {
 	// },[tripList])
 	return (
 		<DragDropContext onDragEnd={onDragEnd}>
-			<Droppable droppableId="mySchedule">
+			{/* <Droppable droppableId="mySchedule">
 				{(provided) => (
-					<div ref={provided.innerRef} {...provided.droppableProps}>
-						<div className="container mx-auto">
-							<div className="flex flex-row justify-between">
-								<div className="w-1/2 mt-20">
-									<CustomCalendar updatedList={updatedList} />
-									{provided.placeholder}
-								</div>
-								<div className="w-1/2 mt-20 ml-10 flex flex-col justify-center">
-									<div className="enrollContainer w-1/2 flex flex-col justify-center mx-auto mt-4 border-solid border-4 border-black rounded-md">
-										<p className="schedule__title mt-4 text-center font-primary-font">
-											내 일정을 입력해보세요
-										</p>
+					<div ref={provided.innerRef} {...provided.droppableProps}> */}
+			<div className="container mx-auto">
+				<div className="flex flex-row justify-between">
+					<div className="w-1/2 mt-20">
+						<CustomCalendar updatedList={updatedList} />
+					</div>
+					<div className="w-1/2 mt-20 ml-10 flex flex-col justify-center">
+						<div className="enrollContainer w-1/2 flex flex-col justify-center mx-auto mt-4 border-solid border-4 border-black rounded-md">
+							<p className="schedule__title mt-4 text-center font-primary-font">
+								내 일정을 입력해보세요
+							</p>
+							<Droppable droppableId="myScheduleList">
+								{(provided) => (
+									<div ref={provided.innerRef} {...provided.droppableProps}>
 										<div className="scheduleList w-full my-4 text-center flex flex-col justify-center">
 											{tripList.map((trip: Trip, index: number) => (
 												<MyScheduleItem
@@ -125,27 +161,30 @@ const MySchedule = () => {
 											))}
 											{provided.placeholder}
 										</div>
-										<div className="btnContainer my-5 mx-auto flex flex-row justify-center gap-4">
-											<button
-												className="addSchedule w-full mx-auto mt-5 bg-black border-2 border-black rounded-lg text-white text-sm"
-												onClick={() => router.push('/choose')}
-											>
-												일정 추가
-											</button>
-											<button
-												className="deleteSchedule w-full mx-auto mt-5 border-2 bg-black border-black rounded-lg text-white text-sm"
-												onClick={removeItem}
-											>
-												일정 삭제
-											</button>
-										</div>
 									</div>
-								</div>
+								)}
+							</Droppable>
+							<div className="btnContainer my-5 mx-auto flex flex-row justify-center gap-4">
+								<button
+									className="addSchedule w-full mx-auto mt-5 bg-black border-2 border-black rounded-lg text-white text-sm"
+									onClick={() => router.push('/choose')}
+								>
+									일정 추가
+								</button>
+								<button
+									className="deleteSchedule w-full mx-auto mt-5 border-2 bg-black border-black rounded-lg text-white text-sm"
+									onClick={removeItem}
+								>
+									일정 삭제
+								</button>
 							</div>
 						</div>
 					</div>
+				</div>
+			</div>
+			{/* </div>
 				)}
-			</Droppable>
+			</Droppable> */}
 		</DragDropContext>
 	);
 };

--- a/components/Calendar/CustomCalendar.tsx
+++ b/components/Calendar/CustomCalendar.tsx
@@ -67,10 +67,15 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 						</div>
 					</div>
 				))}
-				{daysNumber.map((dayNumber: number, dayIndex: number) => (
-					<div key={dayNumber} className="day__cell border-t min-h-[4rem]">
+				{daysNumber.map((dayNumber: number) => (
+					<div
+						key={dayNumber}
+						className="day__cell border-t w-full min-h-[4rem] hover:bg-primary-color"
+					>
 						<div className="day__count text-lg">{dayNumber}</div>
-						<Droppable droppableId={`droppable-${year}-${month}-${dayNumber}`}>
+						<Droppable
+							droppableId={`droppable-${year}-${month}-${dayNumber + 1}`}
+						>
 							{(provided) => (
 								<div
 									ref={provided.innerRef}
@@ -80,8 +85,8 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 									{updatedList
 										.filter(
 											(trip) =>
-												trip.currentDay <= dayNumber &&
-												trip.endDay >= dayNumber &&
+												trip.currentDay <= dayNumber + 1 &&
+												trip.endDay >= dayNumber + 1 &&
 												trip.currentYear === year &&
 												trip.currentMonth === month,
 										)

--- a/components/Calendar/CustomCalendar.tsx
+++ b/components/Calendar/CustomCalendar.tsx
@@ -68,9 +68,9 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 					</div>
 				))}
 				{daysNumber.map((dayNumber: number, dayIndex: number) => (
-					<div key={dayNumber} className="day__cell border-t">
+					<div key={dayNumber} className="day__cell border-t min-h-[4rem]">
 						<div className="day__count text-lg">{dayNumber}</div>
-						<Droppable droppableId={`droppable-${dayNumber + 1}`}>
+						<Droppable droppableId={`droppable-${year}-${month}-${dayNumber}`}>
 							{(provided) => (
 								<div
 									ref={provided.innerRef}
@@ -78,7 +78,13 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 									className="schedule__container text-sm w-full"
 								>
 									{updatedList
-										.filter((trip) => trip.day === dayNumber)
+										.filter(
+											(trip) =>
+												trip.currentDay <= dayNumber &&
+												trip.endDay >= dayNumber &&
+												trip.currentYear === year &&
+												trip.currentMonth === month,
+										)
 										.map((trip, index) => (
 											<MyScheduleItem
 												key={trip.trip_id}

--- a/components/Calendar/CustomCalendar.tsx
+++ b/components/Calendar/CustomCalendar.tsx
@@ -1,6 +1,6 @@
 import { goNextDate, goPrevDate } from '@/hooks/useGetDate';
 import React, { useEffect, useState } from 'react';
-
+import { BsChevronLeft, BsChevronRight } from 'react-icons/bs';
 import { Draggable, Droppable } from '@hello-pangea/dnd';
 import { Trip } from '@/interfaces/myschedule';
 import MyScheduleItem from './MyScheduleItem';
@@ -41,20 +41,20 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 	}, [year, month, lastDateOfMonth]);
 
 	return (
-		<div className="container my-5 flex flex-col justify-center border rounded-lg text-center">
-			<div className="calendar__header mx-auto">
-				<span>Calendar</span>
-				<button className="prev__btn mx-3" onClick={goPrevMonth}>
-					&lt;
+		<div className="container my-5 flex flex-col justify-center border-2 shadow rounded-lg text-center px-3 py-2">
+			<div className="calendar__header mx-auto flex gap-2 items-center">
+				<span>My Calendar</span>
+				<button className="prev__btn text-sm" onClick={goPrevMonth}>
+					<BsChevronLeft />
 				</button>
-				<span>
+				<span className="currentDate font-bold text-sm">
 					{year} {month}
 				</span>
-				<button className="next__btn mx-3" onClick={goNextMonth}>
-					&gt;
+				<button className="next__btn text-sm" onClick={goNextMonth}>
+					<BsChevronRight />
 				</button>
 			</div>
-			<div className="calendar__container w-full grid grid-cols-7 gap-4 border-4">
+			<div className="calendar__container w-full grid grid-cols-7 gap-4">
 				{days.map((today: string, index: number) => (
 					<div key={index} className="day__cell">
 						<div className="day__header mt-3 font-primary-font text-primary-color">
@@ -72,7 +72,7 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 				{daysNumber.map((dayNumber: number) => (
 					<div
 						key={dayNumber}
-						className="day__cell border-t w-full min-h-[4rem] hover:border-2 border-primary-color hover:scale-110 rounded-md"
+						className="day__cell border-t border-bg-grey-200 w-full min-h-[4rem] hover:border-2 scale-110 hover:border-green-100 rounded-md"
 					>
 						<div className="day__count text-lg">{dayNumber}</div>
 						<Droppable
@@ -85,13 +85,26 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 									className="schedule__container text-sm w-full"
 								>
 									{updatedList
-										.filter(
-											(trip) =>
-												trip.currentDay <= dayNumber + 1 &&
-												trip.endDay >= dayNumber + 1 &&
-												trip.currentYear === year &&
-												trip.currentMonth === month,
-										)
+										.filter((trip) => {
+											// 계산된 이벤트의 시작일과 종료일 범위를 구함
+											const eventStart = new Date(
+												trip.currentYear,
+												trip.currentMonth - 1,
+												trip.currentDay,
+											);
+											const eventEnd = new Date(
+												trip.currentYear,
+												trip.currentMonth - 1,
+												trip.endDay,
+											);
+
+											// 현재 날짜와 비교하여 해당 달에 표시
+											return (
+												eventStart <=
+													new Date(year, month - 1, dayNumber + 1) &&
+												eventEnd >= new Date(year, month - 1, dayNumber + 1)
+											);
+										})
 										.map((trip, index) => (
 											<MyScheduleItem
 												key={trip.trip_id}

--- a/components/Calendar/CustomCalendar.tsx
+++ b/components/Calendar/CustomCalendar.tsx
@@ -16,6 +16,8 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 	const firstDay = firstDayOfMonth.getDay(); // 매달 1일의 요일
 	const lastDateOfMonth = lastDayOfMonth.getDate(); // 매달 마지막날의 날짜
 	const prevMonthOfLastDate = new Date(year, month - 1, 0).getDate();
+	const startOfMonth = new Date(year, month - 1, 1);
+	const endOfMonth = new Date(year, month, 0);
 
 	const days = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -70,7 +72,7 @@ const CustomCalendar = ({ updatedList }: { updatedList: Trip[] }) => {
 				{daysNumber.map((dayNumber: number) => (
 					<div
 						key={dayNumber}
-						className="day__cell border-t w-full min-h-[4rem] hover:bg-primary-color"
+						className="day__cell border-t w-full min-h-[4rem] hover:border-2 border-primary-color hover:scale-110 rounded-md"
 					>
 						<div className="day__count text-lg">{dayNumber}</div>
 						<Droppable

--- a/components/Calendar/MyScheduleItem.tsx
+++ b/components/Calendar/MyScheduleItem.tsx
@@ -20,7 +20,7 @@ const MyScheduleItem = ({ title, index, trip }: IMyScheduleItem) => {
 					{...provided.dragHandleProps}
 				>
 					<Chip
-						className={`w-full max-w-[12rem] mx-auto mt-5 ${
+						className={`w-full max-w-[12rem] mx-auto mt-5 shadow hover:scale-110 ${
 							trip.trip_schedule === 1
 								? 'bg-yellow-500'
 								: trip.trip_schedule === 2

--- a/components/Calendar/MyScheduleItem.tsx
+++ b/components/Calendar/MyScheduleItem.tsx
@@ -20,7 +20,7 @@ const MyScheduleItem = ({ title, index, trip }: IMyScheduleItem) => {
 					{...provided.dragHandleProps}
 				>
 					<Chip
-						className={`w-1/2 mx-auto mt-5 ${
+						className={`w-full max-w-[12rem] mx-auto mt-5 ${
 							trip.trip_schedule === 1
 								? 'bg-yellow-500'
 								: trip.trip_schedule === 2

--- a/interfaces/myschedule.ts
+++ b/interfaces/myschedule.ts
@@ -12,7 +12,10 @@ export interface Trip {
 	trip_id: string;
 	trip_name: string;
 	trip_schedule: number;
-	day: number;
+	currentYear: number;
+	currentMonth: number;
+	currentDay: number;
+	endDay: number;
 }
 export interface IMyScheduleItem {
 	title: string;


### PR DESCRIPTION
close #48 
구현 사항
1. 달력 스케줄 길이대로 달력에 넣기
2. 2023년 12월 30일날에 3일짜리 스케줄 등록하면 2024년 1월로 이월되게 하기 -> 다음 년,월에도 등록 잘되게 함
3. 1차 스타일링 -> react-icons 라이브러리 설치
4. 달력 hover 된 날짜에 드롭했을 때 그 날짜에 정확히 드롭 안됐던 에러 해결